### PR TITLE
doc: nrf_modem: add nrf_fcnt_flags to documentation

### DIFF
--- a/nrf_modem/doc/api.rst
+++ b/nrf_modem/doc/api.rst
@@ -98,6 +98,10 @@ fcntl parameters
    :project: nrfxlib
    :members:
 
+.. doxygengroup:: nrf_fcnt_flags
+   :project: nrfxlib
+   :members:
+
 Socket API
 **********
 


### PR DESCRIPTION
Add nrf_fcnt_flags to the documentation.

Signed-off-by: Eivind Jølsgard <eivind.jolsgard@nordicsemi.no>