### PR TITLE
nrf_modem: use different binaries for nRF9160 and nRF9120

### DIFF
--- a/nrf_modem/CMakeLists.txt
+++ b/nrf_modem/CMakeLists.txt
@@ -6,19 +6,22 @@
 
 if(CONFIG_NRF_MODEM_LINK_BINARY)
 
-  nrfxlib_calculate_lib_path(NRF_MODEM_LIB_DIR
-    BASE_DIR ${CMAKE_CURRENT_SOURCE_DIR}
+  nrfxlib_calculate_lib_path(NRF_MODEM_LIB_DIR SOC_MODE
     SOFT_FLOAT_FALLBACK
   )
+
+  if(NOT NRF_MODEM_LIB_DIR MATCHES "nRF9160")
+  string(REGEX REPLACE "nRF91[0-9]*" "nRF9120" NRF_MODEM_LIB_DIR ${NRF_MODEM_LIB_DIR})
+  endif()
 
   if(NOT NRF_MODEM_LIB_DIR)
      message(ERROR " This combination of SoC and floating point ABI is not supported by libmodem.")
   endif()
 
   if(CONFIG_NRF_MODEM_LOG)
-    zephyr_library_import(modem ${NRF_MODEM_LIB_DIR}/libmodem_log.a)
+    zephyr_library_import(modem ${CMAKE_CURRENT_SOURCE_DIR}/${NRF_MODEM_LIB_DIR}/libmodem_log.a)
   else()
-    zephyr_library_import(modem ${NRF_MODEM_LIB_DIR}/libmodem.a)
+    zephyr_library_import(modem ${CMAKE_CURRENT_SOURCE_DIR}/${NRF_MODEM_LIB_DIR}/libmodem.a)
   endif()
 
   zephyr_include_directories(include)


### PR DESCRIPTION
Use different binaries dependent on the SoC.