### PR TITLE
nrf_modem: doc: remove sockopt custom types

### DIFF
--- a/nrf_modem/doc/CHANGELOG.rst
+++ b/nrf_modem/doc/CHANGELOG.rst
@@ -9,6 +9,14 @@ Changelog
 
 All notable changes to this project are documented in this file.
 
+nrf_modem 2.6.0
+***************
+
+sockets
+=======
+
+* Deprecated the ``nrf_sec_cipher_t``, ``nrf_sec_peer_verify_t``, ``nrf_sec_role_t``, and ``nrf_sec_session_cache_t`` types. Use ``int`` instead.
+
 nrf_modem 2.5.0
 ***************
 

--- a/nrf_modem/doc/sockets.rst
+++ b/nrf_modem/doc/sockets.rst
@@ -72,13 +72,13 @@ The following table shows all socket options supported by the Modem library.
 +-----------------+---------------------------------+------------------------+------------+--------------------------------------------------------------------------------------------+
 | NRF_SOL_SECURE  | NRF_SO_SEC_HOSTNAME             | ``char *``             | get/set    | Set/get the hostname to check against during TLS handshakes.                               |
 +-----------------+---------------------------------+------------------------+------------+--------------------------------------------------------------------------------------------+
-| NRF_SOL_SECURE  | NRF_SO_SEC_CIPHERSUITE_LIST     | ``nrf_sec_cipher_t *`` | get/set    | Set/get allowed cipher suite list.                                                         |
+| NRF_SOL_SECURE  | NRF_SO_SEC_CIPHERSUITE_LIST     | ``int *``              | get/set    | Set/get allowed cipher suite list.                                                         |
 +-----------------+---------------------------------+------------------------+------------+--------------------------------------------------------------------------------------------+
-| NRF_SOL_SECURE  | NRF_SO_SEC_PEER_VERIFY          | ``nrf_peer_verify_t``  | get/set    | Set/get Peer verification level.                                                           |
+| NRF_SOL_SECURE  | NRF_SO_SEC_PEER_VERIFY          | ``int``                | get/set    | Set/get Peer verification level.                                                           |
 +-----------------+---------------------------------+------------------------+------------+--------------------------------------------------------------------------------------------+
-| NRF_SOL_SECURE  | NRF_SO_SEC_ROLE                 | ``nrf_sec_role_t``     | get/set    | Set/get TLS role.                                                                          |
+| NRF_SOL_SECURE  | NRF_SO_SEC_ROLE                 | ``int``                | get/set    | Set/get TLS role.                                                                          |
 +-----------------+---------------------------------+------------------------+------------+--------------------------------------------------------------------------------------------+
-| NRF_SOL_SECURE  | NRF_SO_SEC_SESSION_CACHE        | ``nrf_session_cache_t``| get/set    | Non-zero enables TLS session cache.                                                        |
+| NRF_SOL_SECURE  | NRF_SO_SEC_SESSION_CACHE        | ``int``                | get/set    | Non-zero enables TLS session cache.                                                        |
 +-----------------+---------------------------------+------------------------+------------+--------------------------------------------------------------------------------------------+
 | NRF_SOL_SECURE  | NRF_SO_SEC_SESSION_CACHE_PURGE  | ``int``                | set        | Delete TLS session cache.                                                                  |
 +-----------------+---------------------------------+------------------------+------------+--------------------------------------------------------------------------------------------+


### PR DESCRIPTION
This commit updates the documentation to remove the custom types `nrf_sec_cipher_t`, `nrf_sec_peer_verify_t`, `nrf_sec_role_t`, and `nrf_sec_session_cache_t`.