### PR TITLE
nrf_modem: doc: refactor RAI

### DIFF
--- a/doc/links.txt
+++ b/doc/links.txt
@@ -104,3 +104,5 @@
 .. _`nPM1300 Evaluation Kit`: https://infocenter.nordicsemi.com/
 
 .. _`Wireshark`: https://www.wireshark.org/
+
+.. _`3GPP TS 24.301 Technical Specification`: https://www.3gpp.org/DynaReport/24301.htm

--- a/nrf_modem/doc/CHANGELOG.rst
+++ b/nrf_modem/doc/CHANGELOG.rst
@@ -16,6 +16,8 @@ sockets
 =======
 
 * Deprecated the ``nrf_sec_cipher_t``, ``nrf_sec_peer_verify_t``, ``nrf_sec_role_t``, and ``nrf_sec_session_cache_t`` types. Use ``int`` instead.
+* Deprecated the RAI socket options :c:macro:`NRF_SO_RAI_NO_DATA`, :c:macro:`NRF_SO_RAI_LAST`, :c:macro:`NRF_SO_RAI_ONE_RESP`, :c:macro:`NRF_SO_RAI_ONGOING`, and :c:macro:`NRF_SO_RAI_WAIT_MORE`.
+* Added the RAI socket option :c:macro:`NRF_SO_RAI` and the values :c:macro:`NRF_RAI_NO_DATA`, :c:macro:`NRF_RAI_LAST`, :c:macro:`NRF_RAI_ONE_RESP`, :c:macro:`NRF_RAI_ONGOING`, and :c:macro:`NRF_RAI_WAIT_MORE`.
 
 nrf_modem 2.5.0
 ***************

--- a/nrf_modem/doc/sockets.rst
+++ b/nrf_modem/doc/sockets.rst
@@ -58,15 +58,7 @@ The following table shows all socket options supported by the Modem library.
 +-----------------+---------------------------------+------------------------+------------+--------------------------------------------------------------------------------------------+
 | NRF_SOL_SOCKET  | NRF_SO_EXCEPTIONAL_DATA         | ``int``                | get/set    | Send data on socket as part of exceptional event.                                          |
 +-----------------+---------------------------------+------------------------+------------+--------------------------------------------------------------------------------------------+
-| NRF_SOL_SOCKET  | NRF_SO_RAI_LAST                 | ``int``                | set        | Enter Radio Resource Control (RRC) idle immediately after the next send operation.         |
-+-----------------+---------------------------------+------------------------+------------+--------------------------------------------------------------------------------------------+
-| NRF_SOL_SOCKET  | NRF_SO_RAI_ONE_RESP             | ``int``                | set        | Wait for one incoming packet after the next send operation, before entering RRC idle mode. |
-+-----------------+---------------------------------+------------------------+------------+--------------------------------------------------------------------------------------------+
-| NRF_SOL_SOCKET  | NRF_SO_RAI_ONGOING              | ``int``                | set        | Keep RRC in connected mode after the next send operation (client).                         |
-+-----------------+---------------------------------+------------------------+------------+--------------------------------------------------------------------------------------------+
-| NRF_SOL_SOCKET  | NRF_SO_RAI_WAIT_MORE            | ``int``                | set        | Keep RRC in connected mode after the next send operation (server).                         |
-+-----------------+---------------------------------+------------------------+------------+--------------------------------------------------------------------------------------------+
-| NRF_SOL_SOCKET  | NRF_SO_RAI_NO_DATA              | ``int``                | set        | Immediately release the RRC.                                                               |
+| NRF_SOL_SOCKET  | NRF_SO_RAI                      | ``int``                | set        | Release Assistance Indication (RAI).                                                       |
 +-----------------+---------------------------------+------------------------+------------+--------------------------------------------------------------------------------------------+
 | NRF_SOL_SECURE  | NRF_SO_SEC_TAG_LIST             | ``nrf_sec_tag_t *``    | get/set    | Set/get the security tag associated with a socket.                                         |
 +-----------------+---------------------------------+------------------------+------------+--------------------------------------------------------------------------------------------+
@@ -159,27 +151,16 @@ NRF_SO_EXCEPTIONAL_DATA
 
    The socket option is supported from modem firmware v2.0.0.
 
-NRF_SO_RAI_LAST
-   This is a Release assistance indication (RAI) socket option.
-   Enter RRC idle mode after the next output operation on this socket is complete.
+NRF_SO_RAI
+   This socket option is used for Release Assistance Indication (RAI).
+   The following values are accepted:
 
-NRF_SO_RAI_ONE_RESP
-   This is a Release assistance indication (RAI) socket option.
-   After the next output operation is complete, wait for one more packet to be received from the network on this socket before entering RRC idle mode.
-
-NRF_SO_RAI_ONGOING
-   This is a Release assistance indication (RAI) socket option.
-   Keep RRC in connected mode after the next output operation on this socket (client side).
-
-NRF_SO_RAI_WAIT_MORE
-   This is a Release assistance indication (RAI) socket option.
-   Keep RRC in connected mode after the next output operation on this socket (server side).
-
-NRF_SO_RAI_NO_DATA
-   This is a Release assistance indication (RAI) socket option.
-   Immediately enter RRC idle mode for this socket.
-   Does not require a following output operation.
-
+    * :c:macro:`NRF_RAI_NO_DATA` - Immediately enter RRC idle mode for this socket. Does not require a following output operation.
+    * :c:macro:`NRF_RAI_LAST` - Enter RRC idle mode after the next output operation on this socket is complete.
+    * :c:macro:`NRF_RAI_ONE_RESP` - After the next output operation is complete, wait for one more packet to be received from the network on this socket before entering RRC idle mode.
+    * :c:macro:`NRF_RAI_ONGOING` - Keep RRC in connected mode after the next output operation on this socket (client side).
+    * :c:macro:`NRF_RAI_WAIT_MORE` - Keep RRC in connected mode after the next output operation on this socket (server side).
+      
 NRF_SO_SILENCE_ALL
    Disable ICMP echo replies on both IPv4 and IPv6.
    The option value is an integer, a ``1`` value disables echo replies.
@@ -532,3 +513,161 @@ For example, see the following code:
 	}
 
 Note that as in the case of other TLS/DTLS socket options, you must do this configuration before connecting to the server.
+
+.. _release_assistance_indication:
+
+Release Assistance Indication (RAI)
+***********************************
+
+Release Assistance Indication (RAI) is a feature introduced in 3GPP Release 13 and further enhanced in Release 14.
+It is designed to optimize the power consumption of IoT devices by allowing them to inform the network that they do not expect any more data to be sent or received after their current transmission.
+This enables the device to transition to a low-power state more quickly.
+RAI is particularly useful for devices operating on LTE-M and NB-IoT networks, where power efficiency is crucial.
+By using RAI, devices can reduce the time they spend in the higher power-consuming RRC_CONNECTED state, thus saving battery life.
+
+.. note::
+   The decision to release the connection is still at the discretion of the network provider.
+
+There are two types of RAI:
+
+* Control Plane RAI (CP-RAI) - Used for control plane data in NB-IoT.
+* Access Stratum RAI (AS-RAI) - Used for both control plane and user plane data in LTE-M and NB-IoT.
+
+The following are the advantages of using RAI:
+
+* Reduced Power Consumption - By avoiding unnecessary RRC connection states, devices conserve power.
+* Improved Battery Life - Extends the operational lifespan of battery-powered IoT devices.
+* Enhanced Network Efficiency - Helps in reducing network congestion by minimizing the time devices spend connected to the network.
+
+Enabling RAI
+============
+
+RAI can be enabled or disabled using the following AT commands:
+
+* To enable: ``AT%RAI=1``
+* To disable: ``AT%RAI=0``
+
+Using RAI
+=========
+
+After enabling RAI, you control it using the :c:func:`nrf_setsockopt` function with the :c:macro:`NRF_SO_RAI` socket option and with the following values:
+
+* :c:macro:`NRF_RAI_NO_DATA` - No more outgoing data and no incoming data are expected.
+* :c:macro:`NRF_RAI_LAST` - No more outgoing data after the next send operation.
+* :c:macro:`NRF_RAI_ONE_RESP` - Expecting a single response after the next send operation.
+* :c:macro:`NRF_RAI_ONGOING` - The socket is actively used, and the connection should be maintained.
+* :c:macro:`NRF_RAI_WAIT_MORE` - The socket is actively used by a server application, and the connection should be maintained.
+
+Code examples
+=============
+
+The following code snippets illustrate some cases on how to apply RAI using the :c:func:`nrf_setsockopt()` function.
+
+An example that shows how to use :c:macro:`NRF_RAI_LAST` when sending a UDP packet:
+
+.. code-block:: c
+
+   #include <nrf_socket.h>
+
+   int send_udp_packet_with_rai_last(int fd)
+   {
+       int err;
+       const char message[] = "Hello, World!";
+       struct nrf_sockaddr_in dest_addr = {
+           .sin_family = NRF_AF_INET,
+           .sin_port = nrf_htons(1234),
+           .sin_addr = {
+               .s_addr = nrf_htonl(NRF_INADDR_ANY)
+           }
+       };
+
+       /* Set the RAI_LAST option to indicate that no further data will be sent after this packet */
+       int option = NRF_RAI_LAST;
+       err = nrf_setsockopt(fd, NRF_SOL_SOCKET, NRF_SO_RAI, &option, sizeof(option));
+       if (err) {
+           printf("Failed to set NRF_SO_RAI option, error: %d\n", err);
+           return err;
+       }
+
+       /* Transmit the message */
+       err = nrf_sendto(fd, message, sizeof(message), 0,
+                        (struct nrf_sockaddr *)&dest_addr, sizeof(dest_addr));
+       if (err < 0) {
+           printf("Failed to send UDP packet with RAI_LAST, error: %d\n", err);
+           return err;
+       }
+
+       return 0;
+   }
+
+An example that shows how to use :c:macro:`NRF_RAI_NO_DATA` when receiving a UDP packet:
+
+.. code-block:: c
+
+   #include <nrf_socket.h>
+
+   int receive_udp_packet_and_set_rai_no_data(int fd)
+   {
+       int err;
+       char buffer[128];
+       struct nrf_sockaddr_in src_addr;
+       nrf_socklen_t addrlen = sizeof(src_addr);
+
+       /* Receive an incoming message */
+       err = nrf_recvfrom(fd, buffer, sizeof(buffer), 0,
+                          (struct nrf_sockaddr *)&src_addr, &addrlen);
+       if (err < 0) {
+           printf("Failed to receive UDP packet, error: %d\n", err);
+           return err;
+       }
+
+       /* Set the RAI_NO_DATA option to signal that the device does not expect to send or receive further data */
+       int option = NRF_RAI_NO_DATA;
+       err = nrf_setsockopt(fd, NRF_SOL_SOCKET, NRF_SO_RAI, &option, sizeof(option));
+       if (err) {
+           printf("Failed to set NRF_SO_RAI option, error: %d\n", err);
+           return err;
+       }
+
+       return 0;
+   }
+
+.. important::
+   These examples assume network support for both CP-RAI and AS-RAI to observe the expected results.
+
+.. note::
+   RAI flags can be used for secure sockets similarly to other sockets.
+
+.. note::
+   Implementing RAI should be a strategic decision based on the application's knowledge of its data transmission patterns.
+   If there is uncertainty regarding future data transfers, it is advisable to refrain from using RAI.
+   This caution helps avoid the additional energy expenditure associated with re-establishing the radio connection.
+
+Checking RAI status
+===================
+
+To verify if the RAI information was reported to the network:
+
+* For CP-RAI, check the ``ESM DATA TRANSPORT PDU`` sent by the modem.
+* For AS-RAI, currently, it is not visible in customer builds without specific modem traces.
+
+RAI best practices
+==================
+
+The following are the best practices to be considered while using RAI:
+
+* Use RAI when no additional uplink or downlink traffic is expected in the near term.
+* Avoid using RAI if subsequent data transmission is anticipated, as it may lead to unnecessary RRC bearer reestablishments.
+* Consider each socket separately for RAI usage, and the modem will aggregate the RAI status across all sockets.
+
+References
+==========
+
+* `3GPP TS 24.301 Technical Specification`_
+
+Conclusion
+==========
+
+RAI is a useful feature for optimizing network resource usage and device power consumption.
+By indicating the end of data transmission, devices can potentially reduce the time they spend connected to the network, saving battery life and freeing up network resources.
+The RAI functionality must be tested with your network provider to ensure compatibility and to understand the network's behavior in response to RAI signals.


### PR DESCRIPTION
This commit updates the documentation to remove the deprecated `NRF_SO_RAI_` socket options.
This commit updates the documentation to add the `NRF_SO_RAI` socket
option and the `NRF_RAI_NO_DATA`, `NRF_RAI_LAST`, `NRF_RAI_ONE_RESP`,
`NRF_RAI_ONGOING`, and `NRF_RAI_WAIT_MORE` values.
Added documentation page for RAI.